### PR TITLE
Bug Fix: dragging outside of Draggable area issue

### DIFF
--- a/frontend/src/Pages/Dashboard/Dashboard.js
+++ b/frontend/src/Pages/Dashboard/Dashboard.js
@@ -99,6 +99,9 @@ function Dashboard() {
   }
 
   function handleDragEnd(res) {
+      if (!res.destination) {
+          return;
+      }
     const wlist = [...watchlist];
     const [reordered] = wlist.splice(res.source.index, 1);
     wlist.splice(res.destination.index, 0, reordered);


### PR DESCRIPTION
Fix Application Crash when dragging Watchlist item out of Draggable Area

Fixed by adding a if check that returns nothing when destination is null/undefined

closes #76 